### PR TITLE
Escape html data to not break layout

### DIFF
--- a/src/components/ClipBoardItem.vue
+++ b/src/components/ClipBoardItem.vue
@@ -28,7 +28,8 @@
           </svg>
         </div>
         <div class="data-item-content-wrapper font-medium relative mx-2">
-          <span class="data-item-title overflow-hidden text-sm" v-html="dataShow"> </span>
+          <span v-if="data.type === 'text'" class="data-item-title overflow-hidden text-sm" v-text="dataShow"></span>
+          <span v-else class="data-item-title overflow-hidden text-sm" v-html="dataShow"> </span>
         </div>
         <div
           class="data-item-action w-5 h-5 flex items-center rounded-full transition-all"

--- a/src/components/ClipBoardItem.vue
+++ b/src/components/ClipBoardItem.vue
@@ -95,7 +95,7 @@ const dataShow = computed(() => {
   if (props.data.type == "text") {
     let content = props.data.content_highlight || props.data.content;
     // content 中过转义掉html的标签 只保留 <b>和</b>不转义
-    content = content.replace(/<[^b\/][^>]*>/g, "");
+    content = content.replace(/<\/?([^<>]+)>/g, (m, p1) => p1 === "b" ? m : `&lt;${p1}&gt;`);
     return content;
   } else if (props.data.type == "image") {
     let imgObj = JSON.parse(props.data.content);

--- a/src/components/ClipBoardItem.vue
+++ b/src/components/ClipBoardItem.vue
@@ -28,8 +28,7 @@
           </svg>
         </div>
         <div class="data-item-content-wrapper font-medium relative mx-2">
-          <span v-if="data.type === 'text'" class="data-item-title overflow-hidden text-sm" v-text="dataShow"></span>
-          <span v-else class="data-item-title overflow-hidden text-sm" v-html="dataShow"> </span>
+          <span class="data-item-title overflow-hidden text-sm" v-html="dataShow"> </span>
         </div>
         <div
           class="data-item-action w-5 h-5 flex items-center rounded-full transition-all"


### PR DESCRIPTION
Copied html is being displayed a bit weird when we use the `v-html` attribute. This fix escapes text content, but leaving other content like images untouched. Pasting into the clipboard is not affected.

Before:
![image](https://user-images.githubusercontent.com/2410669/229265330-39243911-d2b4-4d97-b1c5-5a5b9bc95e03.png)

After:
![image](https://user-images.githubusercontent.com/2410669/229265337-3d847cf1-ab51-4e52-8df5-31e5d154f29f.png)

It's still not 100% perfect. For some reason the copied html is clipped/hidden, but I still think it's better than before :) 