### PR TITLE
Autopaste

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2287,6 +2287,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+dependencies = [
+ "log",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,6 +3477,7 @@ dependencies = [
  "objc",
  "once_cell",
  "open",
+ "os_info",
  "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -64,7 +64,7 @@ version = "3.2.0"
 source = "git+https://github.com/ChurchTao/arboard.git#69dfa58ebc9b4c8582bf4abf450df32a5b6a88f8"
 dependencies = [
  "clipboard-win",
- "core-graphics",
+ "core-graphics 0.22.3",
  "image",
  "log",
  "objc",
@@ -336,6 +336,21 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667fdc068627a2816b9ff831201dd9864249d6ee8d190b9532357f1fc0f61ea7"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation 0.9.3",
+ "core-graphics 0.21.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f425db7937052c684daec3bd6375c8abe2d146dca4b8b143d6db777c39138f3a"
@@ -343,8 +358,8 @@ dependencies = [
  "bitflags",
  "block",
  "cocoa-foundation",
- "core-foundation",
- "core-graphics",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
  "foreign-types",
  "libc",
  "objc",
@@ -358,7 +373,7 @@ checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
 dependencies = [
  "bitflags",
  "block",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -399,13 +414,29 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "core-foundation-sys"
@@ -415,12 +446,36 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "core-graphics"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.7.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a67c4378cf203eace8fb6567847eb641fd6ff933c1145a115c6ee820ebb978"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.3",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -433,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.3",
  "foreign-types",
  "libc",
 ]
@@ -1370,7 +1425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
@@ -1586,6 +1641,7 @@ dependencies = [
  "image",
  "once_cell",
  "parking_lot",
+ "rdev",
  "rusqlite",
  "rust-crypto",
  "serde",
@@ -2551,6 +2607,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdev"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f183f2103ea19c0e2ab5c41c930f0fb3270b6ba7695fd0f5d12b73b86e64b10"
+dependencies = [
+ "cocoa 0.22.0",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
+ "core-graphics 0.19.2",
+ "lazy_static",
+ "libc",
+ "winapi",
+ "x11",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2756,8 +2828,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.9.3",
+ "core-foundation-sys 0.8.3",
  "libc",
  "security-framework-sys",
 ]
@@ -2768,7 +2840,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.3",
  "libc",
 ]
 
@@ -3131,9 +3203,9 @@ dependencies = [
  "bitflags",
  "cairo-rs",
  "cc",
- "cocoa",
- "core-foundation",
- "core-graphics",
+ "cocoa 0.24.1",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dirs-next",
  "dispatch",
@@ -3190,7 +3262,7 @@ dependencies = [
  "anyhow",
  "attohttpc",
  "base64 0.13.1",
- "cocoa",
+ "cocoa 0.24.1",
  "dirs-next",
  "embed_plist",
  "encoding_rs",
@@ -3317,7 +3389,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36b1c5764a41a13176a4599b5b7bd0881bea7d94dfe45e1e755f789b98317e30"
 dependencies = [
- "cocoa",
+ "cocoa 0.24.1",
  "gtk",
  "percent-encoding",
  "rand 0.8.5",
@@ -3955,7 +4027,7 @@ name = "window-shadows"
 version = "0.2.1"
 source = "git+https://github.com/tauri-apps/window-shadows#edb79182a5b30aff6f220fd8fa2c106775616fc4"
 dependencies = [
- "cocoa",
+ "cocoa 0.24.1",
  "objc",
  "raw-window-handle",
  "windows-sys",
@@ -4163,8 +4235,8 @@ checksum = "4c1ad8e2424f554cc5bdebe8aa374ef5b433feff817aebabca0389961fc7ef98"
 dependencies = [
  "base64 0.13.1",
  "block",
- "cocoa",
- "core-graphics",
+ "cocoa 0.24.1",
+ "core-graphics 0.22.3",
  "crossbeam-channel",
  "dunce",
  "gdk",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3,6 +3,20 @@
 version = 3
 
 [[package]]
+name = "active-win-pos-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5daf26443399af2cc5fe02bd548d999ca9dd8cc2be63255967fe78e56ed52a5"
+dependencies = [
+ "appkit-nsworkspace-bindings",
+ "core-foundation 0.9.3",
+ "core-graphics 0.22.3",
+ "objc",
+ "windows 0.39.0",
+ "xcb",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,10 +67,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "appkit-nsworkspace-bindings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f463696c5039f3196c70ee81a1fada80ef9a9fdd755218bf4c205416f9849"
+dependencies = [
+ "bindgen",
+ "objc",
+]
 
 [[package]]
 name = "arboard"
@@ -118,6 +151,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "auto-launch"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +189,29 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
 
 [[package]]
 name = "bit_field"
@@ -275,6 +342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +397,32 @@ dependencies = [
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -677,7 +779,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -813,6 +915,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -1380,6 +1495,15 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -1417,6 +1541,12 @@ name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -1632,11 +1762,13 @@ dependencies = [
 name = "lanaya"
 version = "1.1.5"
 dependencies = [
+ "active-win-pos-rs",
  "anyhow",
  "arboard",
  "auto-launch",
  "base64 0.21.0",
  "chrono",
+ "cocoa 0.24.1",
  "dunce",
  "image",
  "once_cell",
@@ -1656,6 +1788,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -1857,6 +1995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +2095,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,7 +2161,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -2197,6 +2351,12 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -2436,6 +2596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2738,6 +2907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3020,6 +3195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3310,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -3437,7 +3624,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58de036c4d2e20717024de2a3c4bf56c301f07b21bc8ef9b57189fce06f1f3b"
 dependencies = [
- "quick-xml",
+ "quick-xml 0.23.1",
  "strum",
  "windows 0.39.0",
 ]
@@ -3474,6 +3661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3769,6 +3965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version-compare"
 version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,6 +4183,17 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"
@@ -4315,6 +4528,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xcb"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0faeb4d7e2d54fff4a0584f61297e86b106914af2029778de7b427f72564d6c5"
+dependencies = [
+ "bitflags",
+ "libc",
+ "quick-xml 0.22.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ chrono = "0.4.23"
 arboard = { git = "https://github.com/ChurchTao/arboard.git" }
 base64 = "0.21.0"
 image = "0.24.5"
+rdev = "0.5.2"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ arboard = { git = "https://github.com/ChurchTao/arboard.git" }
 base64 = "0.21.0"
 image = "0.24.5"
 rdev = "0.5.2"
+cocoa = "0.24.1"
+active-win-pos-rs = "0.7"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-build = { version = "1.2.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2.3", features = ["global-shortcut-all", "macos-private-api", "notification-all", "shell-open", "system-tray", "updater", "window-all"] }
+tauri = { version = "1.2.3", features = ["global-shortcut-all", "macos-private-api", "notification-all", "os-all", "shell-open", "system-tray", "updater", "window-all"] }
 window-shadows = { git = "https://github.com/tauri-apps/window-shadows" }
 auto-launch = "0.4"
 once_cell = "1.17.0"
@@ -29,8 +29,10 @@ arboard = { git = "https://github.com/ChurchTao/arboard.git" }
 base64 = "0.21.0"
 image = "0.24.5"
 rdev = "0.5.2"
-cocoa = "0.24.1"
 active-win-pos-rs = "0.7"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.24.1"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/cmds.rs
+++ b/src-tauri/src/cmds.rs
@@ -7,9 +7,11 @@ use crate::{
         handle::Handle,
     },
     log_err,
-    utils::json_util,
-    utils::dispatch_util,
+    utils::{json_util, dispatch_util},
+    utils::window_util::{focus_window},
+    PreviousProcessId,
 };
+use tauri::State;
 
 type CmdResult<T = ()> = Result<T, String>;
 
@@ -188,7 +190,8 @@ pub fn write_to_clip(id: u64) -> bool {
 }
 
 #[tauri::command]
-pub fn paste_in_previous_window() -> CmdResult {
-    dispatch_util::paste_in_previous_window();
+pub fn paste_in_previous_window(previous_process_id: State<PreviousProcessId>) -> CmdResult {
+    focus_window(*previous_process_id.0.lock().unwrap());
+    dispatch_util::paste();
     Ok(())
 }

--- a/src-tauri/src/cmds.rs
+++ b/src-tauri/src/cmds.rs
@@ -190,6 +190,12 @@ pub fn write_to_clip(id: u64) -> bool {
 }
 
 #[tauri::command]
+pub fn focus_previous_window(previous_process_id: State<PreviousProcessId>) -> CmdResult {
+    focus_window(*previous_process_id.0.lock().unwrap());
+    Ok(())
+}
+
+#[tauri::command]
 pub fn paste_in_previous_window(previous_process_id: State<PreviousProcessId>) -> CmdResult {
     focus_window(*previous_process_id.0.lock().unwrap());
     dispatch_util::paste();

--- a/src-tauri/src/cmds.rs
+++ b/src-tauri/src/cmds.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     log_err,
     utils::json_util,
+    utils::dispatch_util,
 };
 
 type CmdResult<T = ()> = Result<T, String>;
@@ -54,6 +55,19 @@ pub async fn change_record_limit(limit: u32) -> CmdResult {
 pub async fn change_auto_launch(enable: bool) -> CmdResult {
     let _ = config::modify_common_config(CommonConfig {
         enable_auto_launch: Some(enable),
+        ..CommonConfig::default()
+    })
+    .await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn change_auto_paste(enable: bool) -> CmdResult {
+    if enable == true {
+        dispatch_util::request_permissions();
+    }
+    let _ = config::modify_common_config(CommonConfig {
+        enable_auto_paste: Some(enable),
         ..CommonConfig::default()
     })
     .await;
@@ -171,4 +185,10 @@ pub fn write_to_clip(id: u64) -> bool {
             false
         }
     }
+}
+
+#[tauri::command]
+pub fn paste_in_previous_window() -> CmdResult {
+    dispatch_util::paste_in_previous_window();
+    Ok(())
 }

--- a/src-tauri/src/config/common_config.rs
+++ b/src-tauri/src/config/common_config.rs
@@ -10,6 +10,8 @@ pub struct CommonConfig {
     pub theme_mode: Option<String>,
     /// can the app auto startup
     pub enable_auto_launch: Option<bool>,
+    /// can the app paste automatically in previous window
+    pub enable_auto_paste: Option<bool>,
     /// hotkey map
     /// format: {func},{key}
     pub hotkeys: Option<Vec<String>>,
@@ -41,6 +43,7 @@ impl CommonConfig {
             },
             theme_mode: Some("light".into()),
             enable_auto_launch: Some(false),
+            enable_auto_paste: Some(false),
             record_limit: Some(100),
             hotkeys: Some(vec![
                 "clear-history:8+16+91".into(),
@@ -63,6 +66,9 @@ impl CommonConfig {
         if let Some(enable_auto_launch) = other.enable_auto_launch {
             self.enable_auto_launch = Some(enable_auto_launch);
         }
+        if let Some(enable_auto_paste) = other.enable_auto_paste {
+            self.enable_auto_paste = Some(enable_auto_paste);
+        }
         if let Some(record_limit) = other.record_limit {
             self.record_limit = Some(record_limit);
         }
@@ -82,6 +88,7 @@ impl CommonConfig {
         patch!(language);
         patch!(theme_mode);
         patch!(enable_auto_launch);
+        patch!(enable_auto_paste);
         patch!(hotkeys);
         patch!(record_limit);
     }

--- a/src-tauri/src/config/config.rs
+++ b/src-tauri/src/config/config.rs
@@ -57,6 +57,7 @@ pub async fn modify_common_config(patch: CommonConfig) -> Result<()> {
     Config::common().draft().patch_config(patch.clone());
 
     let auto_launch = patch.enable_auto_launch;
+    let auto_paste = patch.enable_auto_paste;
     let language = patch.language;
     let theme_mode = patch.theme_mode;
     let record_limit = patch.record_limit;
@@ -83,6 +84,10 @@ pub async fn modify_common_config(patch: CommonConfig) -> Result<()> {
 
         if record_limit.is_some() {
             handle::Handle::notice_to_window(handle::MsgTypeEnum::ChangeRecordLimit, record_limit)?;
+        }
+
+        if auto_paste.is_some() {
+            handle::Handle::notice_to_window(handle::MsgTypeEnum::ChangeAutoPaste, auto_paste)?;
         }
 
         <Result<()>>::Ok(())

--- a/src-tauri/src/core/handle.rs
+++ b/src-tauri/src/core/handle.rs
@@ -21,6 +21,7 @@ pub enum MsgTypeEnum {
     ChangeRecordLimit,
     ChangeHotKeys,
     ChangeClipBoard,
+    ChangeAutoPaste,
 }
 
 impl Handle {
@@ -111,6 +112,14 @@ impl Handle {
                 if window.is_some() {
                     if let Some(win) = window {
                         win.emit("lanaya://change-clipboard", msg)?;
+                    };
+                }
+            }
+            MsgTypeEnum::ChangeAutoPaste => {
+                let window = app_handle.as_ref().unwrap().get_window("main");
+                if window.is_some() {
+                    if let Some(win) = window {
+                        win.emit("lanaya://change-auto-paste", msg)?;
                     };
                 }
             }

--- a/src-tauri/src/core/handle.rs
+++ b/src-tauri/src/core/handle.rs
@@ -2,13 +2,14 @@ use super::{
     tray::Tray,
     window_manager::{WindowInfo, WindowType},
 };
-use crate::{config::Config, log_err, utils::hotkey_util};
+use crate::{config::Config, log_err, utils::{hotkey_util, window_util}, PreviousProcessId};
 use anyhow::{bail, Result};
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use serde::Serialize;
 use std::sync::Arc;
 use tauri::{AppHandle, GlobalShortcutManager, Manager, Window};
+use tauri::State;
 use window_shadows::set_shadow;
 
 #[derive(Debug, Default, Clone)]
@@ -163,6 +164,12 @@ impl Handle {
 
     pub fn open_window(window_type: WindowType) {
         let binding = Self::global().app_handle.lock();
+        let previous_process_id: State<PreviousProcessId> = binding
+            .as_ref()
+            .expect("Couldn't get app_handle")
+            .state();
+        let mut p_id = previous_process_id.0.lock().unwrap();
+        *p_id = window_util::get_active_process_id();
         let app_handle = binding.as_ref().unwrap();
 
         let window_info = match window_type {
@@ -215,4 +222,5 @@ impl Handle {
             }
         }
     }
+
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
             cmds::delete_over_limit,
             cmds::write_to_clip,
             cmds::delete_by_id,
+            cmds::focus_previous_window,
             cmds::paste_in_previous_window,
         ])
         .build(tauri::generate_context!())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,6 +15,9 @@ mod cmds;
 mod config;
 mod core;
 mod utils;
+use std::sync::Mutex;
+
+pub struct PreviousProcessId(Mutex<i32>);
 
 fn main() {
     let app = tauri::Builder::default()
@@ -24,6 +27,7 @@ fn main() {
         })
         .system_tray(SystemTray::new())
         .on_system_tray_event(core::tray::Tray::on_system_tray_event)
+        .manage(PreviousProcessId(Default::default()))
         .invoke_handler(tauri::generate_handler![
             cmds::get_common_config,
             cmds::set_common_config,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
             cmds::change_language,
             cmds::change_record_limit,
             cmds::change_auto_launch,
+            cmds::change_auto_paste,
             cmds::change_theme_mode,
             cmds::change_hotkeys,
             cmds::clear_data,
@@ -41,6 +42,7 @@ fn main() {
             cmds::delete_over_limit,
             cmds::write_to_clip,
             cmds::delete_by_id,
+            cmds::paste_in_previous_window,
         ])
         .build(tauri::generate_context!())
         .expect("error while build tauri application");

--- a/src-tauri/src/utils/dispatch_util.rs
+++ b/src-tauri/src/utils/dispatch_util.rs
@@ -1,0 +1,56 @@
+use rdev::{simulate, EventType, Key, SimulateError};
+use std::{thread, time};
+
+pub fn paste_in_previous_window() {
+    focus_previous_window();
+    sleep(100);
+    paste();
+}
+
+pub fn focus_previous_window() {
+    // Ideally there's some native function to return focus to previous window,
+    // haven't found it yet though.
+
+    // First run command + tab
+    dispatch(&EventType::KeyPress(Key::MetaLeft));
+    dispatch(&EventType::KeyPress(Key::Tab));
+    dispatch(&EventType::KeyRelease(Key::Tab));
+    sleep(100);
+    // While pressing command key, also run shift + command + tab
+    dispatch(&EventType::KeyPress(Key::ShiftLeft));
+    dispatch(&EventType::KeyPress(Key::Tab));
+    dispatch(&EventType::KeyRelease(Key::Tab));
+    dispatch(&EventType::KeyRelease(Key::ShiftLeft));
+    dispatch(&EventType::KeyRelease(Key::MetaLeft));
+}
+
+pub fn paste() {
+    // Run command + v to paste
+    // Same approach as both Maccy and Clipy, reference: https://github.com/p0deje/Maccy/blob/master/Maccy/Clipboard.swift#L101
+    dispatch(&EventType::KeyPress(Key::MetaLeft));
+    dispatch(&EventType::KeyPress(Key::KeyV));
+    dispatch(&EventType::KeyRelease(Key::KeyV));
+    dispatch(&EventType::KeyRelease(Key::MetaLeft));
+}
+
+pub fn request_permissions() {
+    // Simply press and release the shift key. First time the OS will ask for permissions, then do it without asking.
+    dispatch(&EventType::KeyPress(Key::ShiftLeft));
+    dispatch(&EventType::KeyRelease(Key::ShiftLeft));
+}
+
+fn dispatch(event_type: &EventType) {
+    match simulate(event_type) {
+        Ok(()) => (),
+        Err(SimulateError) => {
+            println!("We could not dispatch {:?}", event_type);
+        }
+    }
+    // Let the OS catchup (at least MacOS)
+    sleep(40)
+}
+
+fn sleep(ms: u64) {
+    let delay = time::Duration::from_millis(ms);
+    thread::sleep(delay);
+}

--- a/src-tauri/src/utils/dispatch_util.rs
+++ b/src-tauri/src/utils/dispatch_util.rs
@@ -1,29 +1,6 @@
 use rdev::{simulate, EventType, Key, SimulateError};
 use std::{thread, time};
 
-pub fn paste_in_previous_window() {
-    focus_previous_window();
-    sleep(100);
-    paste();
-}
-
-pub fn focus_previous_window() {
-    // Ideally there's some native function to return focus to previous window,
-    // haven't found it yet though.
-
-    // First run command + tab
-    dispatch(&EventType::KeyPress(Key::MetaLeft));
-    dispatch(&EventType::KeyPress(Key::Tab));
-    dispatch(&EventType::KeyRelease(Key::Tab));
-    sleep(100);
-    // While pressing command key, also run shift + command + tab
-    dispatch(&EventType::KeyPress(Key::ShiftLeft));
-    dispatch(&EventType::KeyPress(Key::Tab));
-    dispatch(&EventType::KeyRelease(Key::Tab));
-    dispatch(&EventType::KeyRelease(Key::ShiftLeft));
-    dispatch(&EventType::KeyRelease(Key::MetaLeft));
-}
-
 pub fn paste() {
     // Run command + v to paste
     // Same approach as both Maccy and Clipy, reference: https://github.com/p0deje/Maccy/blob/master/Maccy/Clipboard.swift#L101
@@ -47,7 +24,7 @@ fn dispatch(event_type: &EventType) {
         }
     }
     // Let the OS catchup (at least MacOS)
-    sleep(40)
+    sleep(20)
 }
 
 fn sleep(ms: u64) {

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -5,3 +5,4 @@ pub mod json_util;
 pub mod log_print;
 pub mod string_util;
 pub mod dispatch_util;
+pub mod window_util;

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -4,3 +4,4 @@ pub mod img_util;
 pub mod json_util;
 pub mod log_print;
 pub mod string_util;
+pub mod dispatch_util;

--- a/src-tauri/src/utils/window_util.rs
+++ b/src-tauri/src/utils/window_util.rs
@@ -1,0 +1,26 @@
+use active_win_pos_rs::get_active_window;
+use cocoa::base::{nil};
+use cocoa::appkit::{NSRunningApplication, NSApplicationActivateIgnoringOtherApps};
+
+pub fn get_active_process_id() -> i32 {
+    match get_active_window() {
+        Ok(active_window) => {
+            let process_id: i32 = active_window.process_id.try_into().unwrap();
+            process_id
+        },
+        Err(()) => {
+            println!("error occurred while getting the active window");
+            0
+        }
+    }
+}
+
+pub fn focus_window(process_id: i32) {
+    if process_id == 0 {
+        return;
+    }
+    unsafe {
+        let current_app = NSRunningApplication::runningApplicationWithProcessIdentifier(nil, process_id);
+        current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);
+    }
+}

--- a/src-tauri/src/utils/window_util.rs
+++ b/src-tauri/src/utils/window_util.rs
@@ -19,6 +19,7 @@ pub fn focus_window(process_id: i32) {
     if process_id == 0 {
         return;
     }
+    #[cfg(target_os = "macos")]
     unsafe {
         let current_app = NSRunningApplication::runningApplicationWithProcessIdentifier(nil, process_id);
         current_app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,9 @@
       },
       "notification": {
         "all": true
+      },
+      "os": {
+        "all": true
       }
     },
     "systemTray": {

--- a/src/components/child/config/RightSectionCommonConfig.vue
+++ b/src/components/child/config/RightSectionCommonConfig.vue
@@ -40,6 +40,14 @@
         />
       </div>
     </div>
+    <div class="check-config-item h-10 mb-2 flex items-center justify-between">
+      <div class="check-config-item-name text-sm">
+        {{ $t("config.common.enable_auto_paste") }}
+      </div>
+      <div class="check-config-item-value flex items-center">
+        <BaseSwitch v-model="commonConfig.enable_auto_paste" @change="changeAutoPaste" />
+      </div>
+    </div>
     <div class="select-config-item mt-4">
       <div class="select-config-item-name font-medium text-base mb-1">
         {{ $t("config.common.hotkeys") }}
@@ -72,6 +80,7 @@ import {
   setAutoLaunch,
   setThemeMode,
   setHotkeys,
+  setAutoPaste,
 } from "@/service/cmds";
 import { ref, onMounted } from "vue";
 import HotKeyInput from "@/components/child/config/HotKeyInput.vue";
@@ -160,6 +169,11 @@ const changeRecordLimit = async (e) => {
 const changeAutoLaunch = async (e) => {
   commonConfig.value.enable_auto_launch = e;
   setAutoLaunch(e);
+};
+
+const changeAutoPaste = async (e) => {
+  commonConfig.value.enable_auto_paste = e;
+  setAutoPaste(e);
 };
 
 const shortCutChange = async (e) => {

--- a/src/components/child/config/RightSectionCommonConfig.vue
+++ b/src/components/child/config/RightSectionCommonConfig.vue
@@ -40,7 +40,7 @@
         />
       </div>
     </div>
-    <div class="check-config-item h-10 mb-2 flex items-center justify-between">
+    <div v-if="isMacOS" class="check-config-item h-10 mb-2 flex items-center justify-between">
       <div class="check-config-item-name text-sm">
         {{ $t("config.common.enable_auto_paste") }}
       </div>
@@ -85,6 +85,7 @@ import {
 import { ref, onMounted } from "vue";
 import HotKeyInput from "@/components/child/config/HotKeyInput.vue";
 import { languageOptions, themeOptions, recordLimitOptions } from "@/config/constants";
+import { platform } from '@tauri-apps/api/os';
 
 // enable_auto_launch: false
 // language: "zh"
@@ -114,6 +115,7 @@ const recordLimitSelectOption = ref({
   name: "300",
   value: 300,
 });
+const isMacOS = ref(false);
 
 const getCommonConfigFromService = async () => {
   const res = await getCommonConfig();
@@ -147,11 +149,14 @@ const getCommonConfigFromService = async () => {
 
 const init = async () => {
   await getCommonConfigFromService();
+  const platformName = await platform();
+  isMacOS.value = platformName === "darwin";
 };
 
 onMounted(async () => {
   await init();
 });
+
 
 const changeLanguage = async (e) => {
   commonConfig.value.language = e.value;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -48,6 +48,10 @@ export const defaultHotkeys = [
     keys: [13],
   },
   {
+    func: hotkeys_func_enum.COPY,
+    keys: [13, 16],
+  },
+  {
     func: hotkeys_func_enum.QUICK_COPY,
     keys: [91],
   },

--- a/src/i18n/locales/en.yaml
+++ b/src/i18n/locales/en.yaml
@@ -16,6 +16,7 @@ config:
     language: "Language"
     record_limit: "Record Limit"
     theme_mode: "Theme(unrealized)"
+    enable_auto_paste: "Auto paste (requires accessibility permissions)"
     hotkeys: "Hotkeys"
     hotkeys_placeholder: "Input Shortcut"
   about:

--- a/src/service/cmds.js
+++ b/src/service/cmds.js
@@ -70,6 +70,10 @@ export async function deleteById(id) {
   return invoke("delete_by_id", { id });
 }
 
+export async function focusPreviousWindow() {
+  return invoke("focus_previous_window");
+}
+
 export async function pasteInPreviousWindow() {
   return invoke("paste_in_previous_window");
 }

--- a/src/service/cmds.js
+++ b/src/service/cmds.js
@@ -21,6 +21,10 @@ export async function setAutoLaunch(enable) {
   return invoke("change_auto_launch", { enable });
 }
 
+export async function setAutoPaste(enable) {
+  return invoke("change_auto_paste", { enable });
+}
+
 export async function setThemeMode(themeMode) {
   return invoke("change_theme_mode", { themeMode });
 }
@@ -64,4 +68,8 @@ export async function writeToClip(id) {
 
 export async function deleteById(id) {
   return invoke("delete_by_id", { id });
+}
+
+export async function pasteInPreviousWindow() {
+  return invoke("paste_in_previous_window");
 }

--- a/src/service/globalListener.js
+++ b/src/service/globalListener.js
@@ -29,6 +29,13 @@ export const listenClipboardChange = async (consumer) => {
   return unListen;
 };
 
+export const listenAutoPasteChange = async (consumer) => {
+  const unListen = await listen("lanaya://change-auto-paste", async (event) => {
+    consumer(event.payload);
+  });
+  return unListen;
+};
+
 export const listenWindowBlur = async (consumer) => {
   const unlistenBlur = await listen("tauri://blur", async (event) => {
     consumer(event);

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -31,7 +31,7 @@ import {
   listenClipboardChange,
   listenAutoPasteChange,
 } from "@/service/globalListener";
-import { getCommonConfig, pasteInPreviousWindow, writeToClip } from "../service/cmds";
+import { getCommonConfig, pasteInPreviousWindow, focusPreviousWindow, writeToClip } from "../service/cmds";
 import hotkeys from "hotkeys-js";
 const noResultFlag = ref(false);
 const selectIndex = ref(-1);
@@ -146,6 +146,9 @@ const clickDataItem = async (index) => {
   if (autoPaste && !shiftPressDown) {
     pasteInPreviousWindow();
   }
+  else {
+    focusPreviousWindow();
+  }
 };
 
 const deleteItem = async (index) => {
@@ -161,6 +164,9 @@ const onKeyEnter = async () => {
   closeWindowLater(3000);
   if (autoPaste && !shiftPressDown) {
     pasteInPreviousWindow();
+  }
+  else {
+    focusPreviousWindow();
   }
 };
 
@@ -317,6 +323,7 @@ const initAppShortCut = async (appShortCuts) => {
               break;
             case hotkeys_func_enum.CLOSE_WINDOW:
               closeWindowLater(3000);
+              focusPreviousWindow();
               break;
           }
         }

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -44,6 +44,7 @@ let unlistenClipboardChange;
 let unlistenAutoPasteChange;
 let recordLimit = 300;
 let autoPaste = false;
+let shiftPressDown = false;
 let lastClipBoardData = "";
 /**
  * @type {Array<{id: number, content: string, content_highlight: string}>}
@@ -142,7 +143,7 @@ const clickDataItem = async (index) => {
   let item = clipBoardDataList.value[index];
   writeToClip(item.id);
   closeWindowLater(3000);
-  if (autoPaste) {
+  if (autoPaste && !shiftPressDown) {
     pasteInPreviousWindow();
   }
 };
@@ -158,7 +159,7 @@ const onKeyEnter = async () => {
   let item = clipBoardDataList.value[selectIndex.value];
   await writeToClip(item.id);
   closeWindowLater(3000);
-  if (autoPaste) {
+  if (autoPaste && !shiftPressDown) {
     pasteInPreviousWindow();
   }
 };
@@ -328,6 +329,7 @@ const initAppShortCut = async (appShortCuts) => {
     let key = e.key;
     let isMeta = e.metaKey;
     let isCtrl = e.ctrlKey;
+    shiftPressDown = e.shiftKey;
     let isCmd = isMeta || isCtrl;
     let numberKey = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
     if (isCmd) {
@@ -343,6 +345,7 @@ const initAppShortCut = async (appShortCuts) => {
   document.onkeyup = async (e) => {
     let key = e.key;
     let isCmd = key == "Meta" || key == "Control";
+    shiftPressDown = e.shiftKey;
     if (isCmd) {
       cmdPressDown.value = false;
     }


### PR DESCRIPTION
Added the option to paste automatically when selecting a record. It's off by default, so the user has to enable it. When enabled, the user can skip auto paste by pressing shift + enter or shift + click.

One part of the feature is to activate the previous window (the application that was active when Lanaya opened), and that is done when closed _except_ for on blur event, since the user may have clicked another application to blur. Auto paste and focus previous window is only available for mac users at the moment.

![image](https://user-images.githubusercontent.com/2410669/229897895-5f72f056-5c19-42dc-90b5-9db4f00d21d9.png)

I was a little uncertain if I should put the code in window_manager or not, but I ended up creating a separate window_util, of course feel free to refactor.