### PR TITLE
Case-insensitive highlight

### DIFF
--- a/src-tauri/src/utils/string_util.rs
+++ b/src-tauri/src/utils/string_util.rs
@@ -30,7 +30,7 @@ pub fn highlight(key: &str, content: &str) -> String {
     let mut start = 0;
     let mut end;
 
-    while let Some(i) = content[start..].find(key) {
+    while let Some(i) = content[start..].to_lowercase().find(&key.to_lowercase()) {
         end = start + i;
         res.push_str(&content[start..end]);
         res.push_str(&format!(


### PR DESCRIPTION
Just a small fix, making the highlight case-insensitive.

![image](https://user-images.githubusercontent.com/2410669/229899582-226ff666-ad4c-4b32-9349-603c3f3a07f2.png)
